### PR TITLE
Fix MGffLogger bug when used in IDL_IDLBridge

### DIFF
--- a/src/dist_tools/mgfflogger__define.pro
+++ b/src/dist_tools/mgfflogger__define.pro
@@ -73,6 +73,7 @@ function mgfflogger::_is_tty
   catch, error
   if (error ne 0L) then begin
     catch, /cancel
+    message, /reset
     return, 0
   endif
 


### PR DESCRIPTION
There was an issue using MGffLogger in the IDL_IDLBridge without mglib installed. I found the issue to be due to the !ERROR_STATE not being reset in the catch block within the _is_tty() function. Adding message, /reset resets the error state to success state so that when the IDL_IDLBridge object exits, it does so normally rather than calling the CALLBACK method with an error state reported.